### PR TITLE
Add API usage notebook

### DIFF
--- a/example_api.ipynb
+++ b/example_api.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Solomon Training API Example\n",
+    "\n",
+    "This notebook demonstrates how to call the training server REST endpoints using `requests`. The API includes:\n",
+    "\n",
+    "- **POST `/api/v1/login`** \u2013 obtain an access token\n",
+    "- **POST `/api/v1/dataset`** \u2013 create a dataset\n",
+    "- **POST `/api/v1/training`** \u2013 trigger a training job\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "import requests\n",
+    "\n",
+    "BASE_URL = 'http://dmg.local'\n",
+    "LOGIN_ENDPOINT = '/api/v1/login'\n",
+    "DATASET_ENDPOINT = '/api/v1/dataset'\n",
+    "TRAINING_ENDPOINT = '/api/v1/training'\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def login(username: str, password: str):\n",
+    "    url = f\"{BASE_URL}{LOGIN_ENDPOINT}\"\n",
+    "    resp = requests.post(url, json={\n",
+    "        'username': username,\n",
+    "        'password': password,\n",
+    "    })\n",
+    "    resp.raise_for_status()\n",
+    "    data = resp.json()\n",
+    "    return data['token'], data['refresh_token']\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def create_dataset(token: str, dataset_name: str, tool_name: str, train_box=True, train_mask=False):\n",
+    "    url = f\"{BASE_URL}{DATASET_ENDPOINT}\"\n",
+    "    headers = {'x-refresh-token': f'Bearer {token}'}\n",
+    "    payload = {\n",
+    "        'dataset_name': dataset_name,\n",
+    "        'tool_name': tool_name,\n",
+    "        'train_box': train_box,\n",
+    "        'train_mask': train_mask,\n",
+    "    }\n",
+    "    resp = requests.post(url, json=payload, headers=headers)\n",
+    "    resp.raise_for_status()\n",
+    "    return resp.json()\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "def trigger_training(token: str, dataset_id: int):\n",
+    "    url = f\"{BASE_URL}{TRAINING_ENDPOINT}\"\n",
+    "    headers = {'x-refresh-token': f'Bearer {token}'}\n",
+    "    resp = requests.post(url, json={'dataset_id': dataset_id}, headers=headers)\n",
+    "    resp.raise_for_status()\n",
+    "    return resp.json()\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "# Example usage\n",
+    "user = 'testuser'\n",
+    "password = 'solomontest'\n",
+    "# token, refresh_token = login(user, password)\n",
+    "# dataset = create_dataset(token, 'DatasetTest0616', 'ObjectDetectionV1')\n",
+    "# training = trigger_training(token, dataset['id'])\n"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sample Responses\n",
+    "\n",
+    "### Login\n",
+    "```json\n",
+    "{\n",
+    "  \"refresh_token\": \"eyJhbGc...\",\n",
+    "  \"token\": \"eyJhbGc...\"\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "### Create Dataset\n",
+    "```json\n",
+    "{\n",
+    "  \"created\": \"2025-06-16T06:16:49.011061\",\n",
+    "  \"cvat_project_id\": 9,\n",
+    "  \"dataset_name\": \"DatasetTest0616\",\n",
+    "  \"id\": 9,\n",
+    "  \"tool_name\": \"ObjectDetectionV1\",\n",
+    "  \"train_box\": true,\n",
+    "  \"train_mask\": false,\n",
+    "  \"updated\": \"2025-06-16T06:16:49.011061\",\n",
+    "  \"user_id\": 7\n",
+    "}\n",
+    "```\n",
+    "\n",
+    "### Trigger Training\n",
+    "```json\n",
+    "{\n",
+    "  \"data\": {\n",
+    "    \"training_info\": {\n",
+    "      \"created\": \"2025-06-16T08:36:55.449115\",\n",
+    "      \"dataset_id\": 9,\n",
+    "      \"id\": 13,\n",
+    "      \"updated\": \"2025-06-16T08:36:55.449115\",\n",
+    "      \"user_id\": 7\n",
+    "    }\n",
+    "  }\n",
+    "}\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- provide example_api.ipynb notebook demonstrating how to use the login, dataset and training endpoints
- include Markdown cells with endpoint summaries and sample responses

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6855e3e26844832f9b0c4560f7d2e807